### PR TITLE
feat: added sourced by supplier in Subcontracting Order

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -109,7 +109,7 @@ class SubcontractingController(StockController):
 		self.__reference_name = []
 
 		if self.doctype in ["Purchase Order", "Subcontracting Order"] or self.is_new():
-			if self.doctype == "Subcontracting Order":
+			if self.doctype == "Subcontracting Order" and self.supplied_items:
 				self.sourced_by_supplier_items = []
 				for supplied_item in self.supplied_items:
 					if supplied_item.sourced_by_supplier:
@@ -568,7 +568,7 @@ class SubcontractingController(StockController):
 			self.__validate_serial_no(row, key)
 
 	def __set_sourced_by_supplier_items(self):
-		if self.sourced_by_supplier_items:
+		if self.get("sourced_by_supplier_items"):
 			for supplied_item in self.supplied_items:
 				for sourced_by_supplier_item in self.sourced_by_supplier_items:
 					if supplied_item.rm_item_code == sourced_by_supplier_item.get("rm_item_code"):

--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -108,7 +108,7 @@ class SubcontractingController(StockController):
 		self.__changed_name = []
 		self.__reference_name = []
 
-		if self.doctype in ["Purchase Order", "Subcontracting Order"] or self.is_new():
+		if self.doctype in ["Purchase Order", "Subcontracting Order"] and self.is_new():
 			self.set(self.raw_material_table, [])
 			return
 
@@ -354,6 +354,7 @@ class SubcontractingController(StockController):
 			"description",
 			"item_name",
 			"stock_uom",
+			"sourced_by_supplier",
 		]:
 			fields.append(f"`tab{doctype}`.`{field}` As {alias_dict.get(field, field)}")
 
@@ -361,7 +362,6 @@ class SubcontractingController(StockController):
 			[doctype, "parent", "=", bom_no],
 			[doctype, "docstatus", "=", 1],
 			["BOM", "item", "=", item_code],
-			[doctype, "sourced_by_supplier", "=", 0],
 		]
 
 		return (
@@ -561,8 +561,9 @@ class SubcontractingController(StockController):
 
 		self.raw_material_table = raw_material_table
 		self.__identify_change_in_item_table()
-		self.__prepare_supplied_items()
-		self.__validate_supplied_items()
+		if self.is_new():
+			self.__prepare_supplied_items()
+			self.__validate_supplied_items()
 
 	def create_raw_materials_supplied(self, raw_material_table="supplied_items"):
 		self.set_materials_for_subcontracted_items(raw_material_table)
@@ -857,28 +858,31 @@ def make_rm_stock_entry(
 				for rm_item in rm_items:
 
 					if rm_item.get("main_item_code") == fg_item_code or rm_item.get("item_code") == fg_item_code:
-						rm_item_code = rm_item.get("rm_item_code")
+						if not rm_item.get("sourced_by_supplier"):
+							rm_item_code = rm_item.get("rm_item_code")
 
-						items_dict = {
-							rm_item_code: {
-								rm_detail_field: rm_item.get("name"),
-								"item_name": rm_item.get("item_name")
-								or item_wh.get(rm_item_code, {}).get("item_name", ""),
-								"description": item_wh.get(rm_item_code, {}).get("description", ""),
-								"qty": rm_item.get("qty")
-								or max(rm_item.get("required_qty") - rm_item.get("total_supplied_qty"), 0),
-								"from_warehouse": rm_item.get("warehouse") or rm_item.get("reserve_warehouse"),
-								"to_warehouse": subcontract_order.supplier_warehouse,
-								"stock_uom": rm_item.get("stock_uom"),
-								"serial_no": rm_item.get("serial_no"),
-								"batch_no": rm_item.get("batch_no"),
-								"main_item_code": fg_item_code,
-								"allow_alternative_item": item_wh.get(rm_item_code, {}).get("allow_alternative_item"),
+							items_dict = {
+								rm_item_code: {
+									rm_detail_field: rm_item.get("name"),
+									"item_name": rm_item.get("item_name")
+									or item_wh.get(rm_item_code, {}).get("item_name", ""),
+									"description": item_wh.get(rm_item_code, {}).get("description", ""),
+									"qty": rm_item.get("qty")
+									or max(rm_item.get("required_qty") - rm_item.get("total_supplied_qty"), 0),
+									"basic_rate": rm_item.get("rate"),
+									"from_warehouse": rm_item.get("warehouse") or rm_item.get("reserve_warehouse"),
+									"to_warehouse": subcontract_order.supplier_warehouse,
+									"stock_uom": rm_item.get("stock_uom"),
+									"serial_no": rm_item.get("serial_no"),
+									"batch_no": rm_item.get("batch_no"),
+									"main_item_code": fg_item_code,
+									"allow_alternative_item": item_wh.get(rm_item_code, {}).get("allow_alternative_item"),
+								}
 							}
-						}
 
-						stock_entry.add_to_stock_entry_detail(items_dict)
+							stock_entry.add_to_stock_entry_detail(items_dict)
 
+			stock_entry.run_method("set_missing_values")
 			if target_doc:
 				return stock_entry
 			else:

--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -110,6 +110,7 @@ class SubcontractingController(StockController):
 
 		if self.doctype in ["Purchase Order", "Subcontracting Order"] or self.is_new():
 			if self.doctype == "Subcontracting Order" and self.supplied_items:
+				# sourced_by_supplier_items is temporary variable to store the changes made by user
 				self.sourced_by_supplier_items = []
 				for supplied_item in self.supplied_items:
 					if supplied_item.sourced_by_supplier:
@@ -579,6 +580,7 @@ class SubcontractingController(StockController):
 								"sourced_by_supplier": sourced_by_supplier_item.get("sourced_by_supplier"),
 							}
 						)
+						break
 
 	def set_materials_for_subcontracted_items(self, raw_material_table):
 		if self.doctype == "Purchase Invoice" and not self.update_stock:

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -279,7 +279,9 @@ class TestBOM(FrappeTestCase):
 		sco = get_subcontracting_order(
 			service_items=service_items, supplier_warehouse="_Test Warehouse 1 - _TC"
 		)
-		bom_items = sorted([d.item_code for d in bom.items if d.sourced_by_supplier != 1])
+		bom_items = sorted(
+			[d.item_code for d in bom.items]
+		)  # if d.sourced_by_supplier != 1 removed this from here as sco is created with items sourced by supplier
 		supplied_items = sorted([d.rm_item_code for d in sco.supplied_items])
 		self.assertEqual(bom_items, supplied_items)
 

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -142,10 +142,17 @@ frappe.ui.form.on('Subcontracting Order Supplied Item', {
 	sourced_by_supplier: function(frm, cdt, cdn) {
 		let row = locals[cdt][cdn];
 		row.rate = row.amount = 0;
+		let rm_cost = 0;
+		if (frm.doc.items && frm.doc.supplied_items) {
+			frm.doc.items.forEach(item => {
+				rm_cost = frappe.utils.sum(cur_frm.doc.supplied_items.map(a => {
+					return !a.sourced_by_supplier ? a.amount : 0
+				}))
+				item.rm_cost_per_qty = rm_cost / item.qty;
+				frm.refresh_field("items");
+			})
+		}
 		frm.refresh_field("supplied_items");
-		frm.call('update_raw_material_cost').then(r => {
-			frm.refresh_field("items");
-		});
 	}
 })
 

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -138,6 +138,17 @@ frappe.ui.form.on('Subcontracting Order', {
 	}
 });
 
+frappe.ui.form.on('Subcontracting Order Supplied Item', {
+	sourced_by_supplier: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		row.rate = row.amount = 0;
+		frm.refresh_field("supplied_items");
+		frm.call('update_raw_material_cost').then(r => {
+			frm.refresh_field("items");
+		});
+	}
+})
+
 frappe.ui.form.on('Landed Cost Taxes and Charges', {
 	amount: function (frm, cdt, cdn) {
 		frm.events.set_base_amount(frm, cdt, cdn);

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -144,15 +144,14 @@ frappe.ui.form.on('Subcontracting Order Supplied Item', {
 		row.rate = row.amount = 0;
 		let rm_cost = 0;
 		if (frm.doc.items && frm.doc.supplied_items) {
+			rm_cost = frappe.utils.sum(frm.doc.supplied_items.map(rm_item => {
+				return !rm_item.sourced_by_supplier ? rm_item.amount : 0
+			}))
 			frm.doc.items.forEach(item => {
-				rm_cost = frappe.utils.sum(cur_frm.doc.supplied_items.map(a => {
-					return !a.sourced_by_supplier ? a.amount : 0
-				}))
 				item.rm_cost_per_qty = rm_cost / item.qty;
-				frm.refresh_field("items");
 			})
 		}
-		frm.refresh_field("supplied_items");
+		frm.refresh_field(["items", "supplied_items"]);
 	}
 })
 

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -139,16 +139,17 @@ frappe.ui.form.on('Subcontracting Order', {
 });
 
 frappe.ui.form.on('Subcontracting Order Supplied Item', {
-	sourced_by_supplier: function(frm, cdt, cdn) {
+	sourced_by_supplier: function (frm, cdt, cdn) {
 		let row = locals[cdt][cdn];
 		row.rate = row.amount = 0;
 		if (frm.doc.items && frm.doc.supplied_items) {
-			const rm_cost = frappe.utils.sum(frm.doc.supplied_items.map(rm_item => {
-				return !rm_item.sourced_by_supplier ? rm_item.amount : 0
-			}))
 			frm.doc.items.forEach(item => {
 				const rm_cost = frappe.utils.sum(frm.doc.supplied_items.map(rm_item => {
-					return !rm_item.sourced_by_supplier && item.item_code == rm_item.main_item_code ? rm_item.amount : 0
+					if (!rm_item.sourced_by_supplier && item.item_code == rm_item.main_item_code) {
+						return rm_item.amount;
+					} else {
+						return 0;
+					}
 				}))
 				frappe.model.set_value(item.doctype, item.name, "rm_cost_per_qty", rm_cost / item.qty);
 			})

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -147,6 +147,9 @@ frappe.ui.form.on('Subcontracting Order Supplied Item', {
 				return !rm_item.sourced_by_supplier ? rm_item.amount : 0
 			}))
 			frm.doc.items.forEach(item => {
+				const rm_cost = frappe.utils.sum(frm.doc.supplied_items.map(rm_item => {
+					return !rm_item.sourced_by_supplier && item.item_code == rm_item.main_item_code ? rm_item.amount : 0
+				}))
 				frappe.model.set_value(item.doctype, item.name, "rm_cost_per_qty", rm_cost / item.qty);
 			})
 		}

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -142,13 +142,12 @@ frappe.ui.form.on('Subcontracting Order Supplied Item', {
 	sourced_by_supplier: function(frm, cdt, cdn) {
 		let row = locals[cdt][cdn];
 		row.rate = row.amount = 0;
-		let rm_cost = 0;
 		if (frm.doc.items && frm.doc.supplied_items) {
-			rm_cost = frappe.utils.sum(frm.doc.supplied_items.map(rm_item => {
+			const rm_cost = frappe.utils.sum(frm.doc.supplied_items.map(rm_item => {
 				return !rm_item.sourced_by_supplier ? rm_item.amount : 0
 			}))
 			frm.doc.items.forEach(item => {
-				item.rm_cost_per_qty = rm_cost / item.qty;
+				frappe.model.set_value(item.doctype, item.name, "rm_cost_per_qty", rm_cost / item.qty);
 			})
 		}
 		frm.refresh_field(["items", "supplied_items"]);

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -142,7 +142,7 @@ frappe.ui.form.on('Subcontracting Order Supplied Item', {
 	sourced_by_supplier: function (frm, cdt, cdn) {
 		let row = locals[cdt][cdn];
 		row.rate = row.amount = 0;
-		if (frm.doc.items && frm.doc.supplied_items) {
+		if (frm.doc.items.length > 0 && frm.doc.supplied_items.length > 0) {
 			frm.doc.items.forEach(item => {
 				const rm_cost = frappe.utils.sum(frm.doc.supplied_items.map(rm_item => {
 					if (!rm_item.sourced_by_supplier && item.item_code == rm_item.main_item_code) {

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.json
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.json
@@ -1,511 +1,510 @@
 {
-    "actions": [],
-    "allow_auto_repeat": 1,
-    "allow_import": 1,
-    "autoname": "naming_series:",
-    "creation": "2022-04-01 22:39:17.662819",
-    "doctype": "DocType",
-    "document_type": "Document",
-    "engine": "InnoDB",
-    "field_order": [
-        "title",
-        "naming_series",
-        "purchase_order",
-        "supplier",
-        "supplier_name",
-        "supplier_warehouse",
-        "column_break_7",
-        "company",
-        "transaction_date",
-        "schedule_date",
-        "amended_from",
-        "accounting_dimensions_section",
-        "cost_center",
-        "dimension_col_break",
-        "project",
-        "address_and_contact_section",
-        "supplier_address",
-        "address_display",
-        "contact_person",
-        "contact_display",
-        "contact_mobile",
-        "contact_email",
-        "column_break_19",
-        "shipping_address",
-        "shipping_address_display",
-        "billing_address",
-        "billing_address_display",
-        "section_break_24",
-        "column_break_25",
-        "set_warehouse",
-        "items",
-        "section_break_32",
-        "total_qty",
-        "column_break_29",
-        "total",
-        "service_items_section",
-        "service_items",
-        "raw_materials_supplied_section",
-        "set_reserve_warehouse",
-        "supplied_items",
-        "additional_costs_section",
-        "distribute_additional_costs_based_on",
-        "additional_costs",
-        "total_additional_costs",
-        "order_status_section",
-        "status",
-        "column_break_39",
-        "per_received",
-        "printing_settings_section",
-        "select_print_heading",
-        "column_break_43",
-        "letter_head"
-    ],
-    "fields": [
-        {
-            "allow_on_submit": 1,
-            "default": "{supplier_name}",
-            "fieldname": "title",
-            "fieldtype": "Data",
-            "hidden": 1,
-            "label": "Title",
-            "no_copy": 1,
-            "print_hide": 1
-        },
-        {
-            "fieldname": "naming_series",
-            "fieldtype": "Select",
-            "label": "Series",
-            "no_copy": 1,
-            "options": "SC-ORD-.YYYY.-",
-            "print_hide": 1,
-            "reqd": 1,
-            "set_only_once": 1
-        },
-        {
-            "fieldname": "purchase_order",
-            "fieldtype": "Link",
-            "label": "Subcontracting Purchase Order",
-            "options": "Purchase Order",
-            "reqd": 1
-        },
-        {
-            "bold": 1,
-            "fieldname": "supplier",
-            "fieldtype": "Link",
-            "in_global_search": 1,
-            "in_standard_filter": 1,
-            "label": "Supplier",
-            "options": "Supplier",
-            "print_hide": 1,
-            "reqd": 1,
-            "search_index": 1
-        },
-        {
-            "bold": 1,
-            "fetch_from": "supplier.supplier_name",
-            "fieldname": "supplier_name",
-            "fieldtype": "Data",
-            "in_global_search": 1,
-            "label": "Supplier Name",
-            "read_only": 1,
-            "reqd": 1
-        },
-        {
-            "depends_on": "supplier",
-            "fieldname": "supplier_warehouse",
-            "fieldtype": "Link",
-            "label": "Supplier Warehouse",
-            "options": "Warehouse",
-            "reqd": 1
-        },
-        {
-            "fieldname": "column_break_7",
-            "fieldtype": "Column Break",
-            "print_width": "50%",
-            "width": "50%"
-        },
-        {
-            "fieldname": "company",
-            "fieldtype": "Link",
-            "in_standard_filter": 1,
-            "label": "Company",
-            "options": "Company",
-            "print_hide": 1,
-            "remember_last_selected_value": 1,
-            "reqd": 1
-        },
-        {
-            "default": "Today",
-            "fetch_from": "purchase_order.transaction_date",
-            "fetch_if_empty": 1,
-            "fieldname": "transaction_date",
-            "fieldtype": "Date",
-            "in_list_view": 1,
-            "label": "Date",
-            "reqd": 1,
-            "search_index": 1
-        },
-        {
-            "allow_on_submit": 1,
-            "fetch_from": "purchase_order.schedule_date",
-            "fetch_if_empty": 1,
-            "fieldname": "schedule_date",
-            "fieldtype": "Date",
-            "label": "Required By",
-            "read_only": 1
-        },
-        {
-            "fieldname": "amended_from",
-            "fieldtype": "Link",
-            "ignore_user_permissions": 1,
-            "label": "Amended From",
-            "no_copy": 1,
-            "options": "Subcontracting Order",
-            "print_hide": 1,
-            "read_only": 1
-        },
-        {
-            "collapsible": 1,
-            "fieldname": "address_and_contact_section",
-            "fieldtype": "Section Break",
-            "label": "Address and Contact"
-        },
-        {
-            "fetch_from": "supplier.supplier_primary_address",
-            "fetch_if_empty": 1,
-            "fieldname": "supplier_address",
-            "fieldtype": "Link",
-            "label": "Supplier Address",
-            "options": "Address",
-            "print_hide": 1
-        },
-        {
-            "fieldname": "address_display",
-            "fieldtype": "Small Text",
-            "label": "Supplier Address Details",
-            "read_only": 1
-        },
-        {
-            "fetch_from": "supplier.supplier_primary_contact",
-            "fetch_if_empty": 1,
-            "fieldname": "contact_person",
-            "fieldtype": "Link",
-            "label": "Supplier Contact",
-            "options": "Contact",
-            "print_hide": 1
-        },
-        {
-            "fieldname": "contact_display",
-            "fieldtype": "Small Text",
-            "in_global_search": 1,
-            "label": "Contact Name",
-            "read_only": 1
-        },
-        {
-            "fieldname": "contact_mobile",
-            "fieldtype": "Small Text",
-            "label": "Contact Mobile No",
-            "read_only": 1
-        },
-        {
-            "fieldname": "contact_email",
-            "fieldtype": "Small Text",
-            "label": "Contact Email",
-            "options": "Email",
-            "print_hide": 1,
-            "read_only": 1
-        },
-        {
-            "fieldname": "column_break_19",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "shipping_address",
-            "fieldtype": "Link",
-            "label": "Company Shipping Address",
-            "options": "Address",
-            "print_hide": 1
-        },
-        {
-            "fieldname": "shipping_address_display",
-            "fieldtype": "Small Text",
-            "label": "Shipping Address Details",
-            "print_hide": 1,
-            "read_only": 1
-        },
-        {
-            "fieldname": "billing_address",
-            "fieldtype": "Link",
-            "label": "Company Billing Address",
-            "options": "Address"
-        },
-        {
-            "fieldname": "billing_address_display",
-            "fieldtype": "Small Text",
-            "label": "Billing Address Details",
-            "read_only": 1
-        },
-        {
-            "fieldname": "section_break_24",
-            "fieldtype": "Section Break"
-        },
-        {
-            "fieldname": "column_break_25",
-            "fieldtype": "Column Break"
-        },
-        {
-            "depends_on": "purchase_order",
-            "description": "Sets 'Warehouse' in each row of the Items table.",
-            "fieldname": "set_warehouse",
-            "fieldtype": "Link",
-            "label": "Set Target Warehouse",
-            "options": "Warehouse",
-            "print_hide": 1
-        },
-        {
-            "allow_bulk_edit": 1,
-            "depends_on": "purchase_order",
-            "fieldname": "items",
-            "fieldtype": "Table",
-            "label": "Items",
-            "options": "Subcontracting Order Item",
-            "reqd": 1
-        },
-        {
-            "fieldname": "section_break_32",
-            "fieldtype": "Section Break"
-        },
-        {
-            "depends_on": "purchase_order",
-            "fieldname": "total_qty",
-            "fieldtype": "Float",
-            "label": "Total Quantity",
-            "read_only": 1
-        },
-        {
-            "fieldname": "column_break_29",
-            "fieldtype": "Column Break"
-        },
-        {
-            "depends_on": "purchase_order",
-            "fieldname": "total",
-            "fieldtype": "Currency",
-            "label": "Total",
-            "options": "currency",
-            "read_only": 1
-        },
-        {
-            "collapsible": 1,
-            "depends_on": "purchase_order",
-            "fieldname": "service_items_section",
-            "fieldtype": "Section Break",
-            "label": "Service Items"
-        },
-        {
-            "fieldname": "service_items",
-            "fieldtype": "Table",
-            "label": "Service Items",
-            "options": "Subcontracting Order Service Item",
-            "read_only": 1,
-            "reqd": 1
-        },
-        {
-            "collapsible": 1,
-            "collapsible_depends_on": "supplied_items",
-            "depends_on": "supplied_items",
-            "fieldname": "raw_materials_supplied_section",
-            "fieldtype": "Section Break",
-            "label": "Raw Materials Supplied"
-        },
-        {
-            "depends_on": "supplied_items",
-            "description": "Sets 'Reserve Warehouse' in each row of the Supplied Items table.",
-            "fieldname": "set_reserve_warehouse",
-            "fieldtype": "Link",
-            "label": "Set Reserve Warehouse",
-            "options": "Warehouse"
-        },
-        {
-            "fieldname": "supplied_items",
-            "fieldtype": "Table",
-            "label": "Supplied Items",
-            "no_copy": 1,
-            "options": "Subcontracting Order Supplied Item",
-            "print_hide": 1,
-            "read_only": 1
-        },
-        {
-            "collapsible": 1,
-            "collapsible_depends_on": "total_additional_costs",
-            "depends_on": "eval:(doc.docstatus == 0 || doc.total_additional_costs)",
-            "fieldname": "additional_costs_section",
-            "fieldtype": "Section Break",
-            "label": "Additional Costs"
-        },
-        {
-            "fieldname": "additional_costs",
-            "fieldtype": "Table",
-            "label": "Additional Costs",
-            "options": "Landed Cost Taxes and Charges"
-        },
-        {
-            "fieldname": "total_additional_costs",
-            "fieldtype": "Currency",
-            "label": "Total Additional Costs",
-            "print_hide_if_no_value": 1,
-            "read_only": 1
-        },
-        {
-            "collapsible": 1,
-            "fieldname": "order_status_section",
-            "fieldtype": "Section Break",
-            "label": "Order Status"
-        },
-        {
-            "default": "Draft",
-            "fieldname": "status",
-            "fieldtype": "Select",
-            "in_standard_filter": 1,
-            "label": "Status",
-            "no_copy": 1,
-            "options": "Draft\nOpen\nPartially Received\nCompleted\nMaterial Transferred\nPartial Material Transferred\nCancelled",
-            "print_hide": 1,
-            "read_only": 1,
-            "reqd": 1,
-            "search_index": 1
-        },
-        {
-            "fieldname": "column_break_39",
-            "fieldtype": "Column Break"
-        },
-        {
-            "depends_on": "eval:!doc.__islocal",
-            "fieldname": "per_received",
-            "fieldtype": "Percent",
-            "in_list_view": 1,
-            "label": "% Received",
-            "no_copy": 1,
-            "print_hide": 1,
-            "read_only": 1
-        },
-        {
-            "collapsible": 1,
-            "fieldname": "printing_settings_section",
-            "fieldtype": "Section Break",
-            "label": "Printing Settings",
-            "print_hide": 1,
-            "print_width": "50%",
-            "width": "50%"
-        },
-        {
-            "allow_on_submit": 1,
-            "fieldname": "select_print_heading",
-            "fieldtype": "Link",
-            "label": "Print Heading",
-            "no_copy": 1,
-            "options": "Print Heading",
-            "print_hide": 1,
-            "report_hide": 1
-        },
-        {
-            "fieldname": "column_break_43",
-            "fieldtype": "Column Break"
-        },
-        {
-            "allow_on_submit": 1,
-            "fieldname": "letter_head",
-            "fieldtype": "Link",
-            "label": "Letter Head",
-            "options": "Letter Head",
-            "print_hide": 1
-        },
-        {
-            "default": "Qty",
-            "fieldname": "distribute_additional_costs_based_on",
-            "fieldtype": "Select",
-            "label": "Distribute Additional Costs Based On ",
-            "options": "Qty\nAmount"
-        },
-        {
-            "collapsible": 1,
-            "fieldname": "accounting_dimensions_section",
-            "fieldtype": "Section Break",
-            "label": "Accounting Dimensions"
-        },
-        {
-            "fieldname": "cost_center",
-            "fieldtype": "Link",
-            "label": "Cost Center",
-            "options": "Cost Center"
-        },
-        {
-            "fieldname": "dimension_col_break",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "project",
-            "fieldtype": "Link",
-            "label": "Project",
-            "options": "Project"
-        }
-    ],
-    "icon": "fa fa-file-text",
-    "is_submittable": 1,
-    "links": [],
-    "modified": "2022-08-15 14:08:49.204218",
-    "modified_by": "Administrator",
-    "module": "Subcontracting",
-    "name": "Subcontracting Order",
-    "naming_rule": "By \"Naming Series\" field",
-    "owner": "Administrator",
-    "permissions": [
-        {
-            "read": 1,
-            "report": 1,
-            "role": "Stock User"
-        },
-        {
-            "amend": 1,
-            "cancel": 1,
-            "create": 1,
-            "delete": 1,
-            "email": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "Purchase Manager",
-            "share": 1,
-            "submit": 1,
-            "write": 1
-        },
-        {
-            "amend": 1,
-            "cancel": 1,
-            "create": 1,
-            "delete": 1,
-            "email": 1,
-            "print": 1,
-            "read": 1,
-            "report": 1,
-            "role": "Purchase User",
-            "share": 1,
-            "submit": 1,
-            "write": 1
-        },
-        {
-            "permlevel": 1,
-            "read": 1,
-            "role": "Purchase Manager",
-            "write": 1
-        }
-    ],
-    "search_fields": "status, transaction_date, supplier",
-    "show_name_in_global_search": 1,
-    "sort_field": "modified",
-    "sort_order": "DESC",
-    "states": [],
-    "timeline_field": "supplier",
-    "title_field": "supplier_name",
-    "track_changes": 1
+ "actions": [],
+ "allow_auto_repeat": 1,
+ "allow_import": 1,
+ "autoname": "naming_series:",
+ "creation": "2022-04-01 22:39:17.662819",
+ "doctype": "DocType",
+ "document_type": "Document",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "naming_series",
+  "purchase_order",
+  "supplier",
+  "supplier_name",
+  "supplier_warehouse",
+  "column_break_7",
+  "company",
+  "transaction_date",
+  "schedule_date",
+  "amended_from",
+  "accounting_dimensions_section",
+  "cost_center",
+  "dimension_col_break",
+  "project",
+  "address_and_contact_section",
+  "supplier_address",
+  "address_display",
+  "contact_person",
+  "contact_display",
+  "contact_mobile",
+  "contact_email",
+  "column_break_19",
+  "shipping_address",
+  "shipping_address_display",
+  "billing_address",
+  "billing_address_display",
+  "section_break_24",
+  "column_break_25",
+  "set_warehouse",
+  "items",
+  "section_break_32",
+  "total_qty",
+  "column_break_29",
+  "total",
+  "service_items_section",
+  "service_items",
+  "raw_materials_supplied_section",
+  "set_reserve_warehouse",
+  "supplied_items",
+  "additional_costs_section",
+  "distribute_additional_costs_based_on",
+  "additional_costs",
+  "total_additional_costs",
+  "order_status_section",
+  "status",
+  "column_break_39",
+  "per_received",
+  "printing_settings_section",
+  "select_print_heading",
+  "column_break_43",
+  "letter_head"
+ ],
+ "fields": [
+  {
+   "allow_on_submit": 1,
+   "default": "{supplier_name}",
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Title",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "no_copy": 1,
+   "options": "SC-ORD-.YYYY.-",
+   "print_hide": 1,
+   "reqd": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "purchase_order",
+   "fieldtype": "Link",
+   "label": "Subcontracting Purchase Order",
+   "options": "Purchase Order",
+   "reqd": 1
+  },
+  {
+   "bold": 1,
+   "fieldname": "supplier",
+   "fieldtype": "Link",
+   "in_global_search": 1,
+   "in_standard_filter": 1,
+   "label": "Supplier",
+   "options": "Supplier",
+   "print_hide": 1,
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "bold": 1,
+   "fetch_from": "supplier.supplier_name",
+   "fieldname": "supplier_name",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "label": "Supplier Name",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "depends_on": "supplier",
+   "fieldname": "supplier_warehouse",
+   "fieldtype": "Link",
+   "label": "Supplier Warehouse",
+   "options": "Warehouse",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_7",
+   "fieldtype": "Column Break",
+   "print_width": "50%",
+   "width": "50%"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Company",
+   "options": "Company",
+   "print_hide": 1,
+   "remember_last_selected_value": 1,
+   "reqd": 1
+  },
+  {
+   "default": "Today",
+   "fetch_from": "purchase_order.transaction_date",
+   "fetch_if_empty": 1,
+   "fieldname": "transaction_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "purchase_order.schedule_date",
+   "fetch_if_empty": 1,
+   "fieldname": "schedule_date",
+   "fieldtype": "Date",
+   "label": "Required By",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Subcontracting Order",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "address_and_contact_section",
+   "fieldtype": "Section Break",
+   "label": "Address and Contact"
+  },
+  {
+   "fetch_from": "supplier.supplier_primary_address",
+   "fetch_if_empty": 1,
+   "fieldname": "supplier_address",
+   "fieldtype": "Link",
+   "label": "Supplier Address",
+   "options": "Address",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "address_display",
+   "fieldtype": "Small Text",
+   "label": "Supplier Address Details",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "supplier.supplier_primary_contact",
+   "fetch_if_empty": 1,
+   "fieldname": "contact_person",
+   "fieldtype": "Link",
+   "label": "Supplier Contact",
+   "options": "Contact",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "contact_display",
+   "fieldtype": "Small Text",
+   "in_global_search": 1,
+   "label": "Contact Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "contact_mobile",
+   "fieldtype": "Small Text",
+   "label": "Contact Mobile No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "contact_email",
+   "fieldtype": "Small Text",
+   "label": "Contact Email",
+   "options": "Email",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_19",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "shipping_address",
+   "fieldtype": "Link",
+   "label": "Company Shipping Address",
+   "options": "Address",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "shipping_address_display",
+   "fieldtype": "Small Text",
+   "label": "Shipping Address Details",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "billing_address",
+   "fieldtype": "Link",
+   "label": "Company Billing Address",
+   "options": "Address"
+  },
+  {
+   "fieldname": "billing_address_display",
+   "fieldtype": "Small Text",
+   "label": "Billing Address Details",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_24",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_25",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "purchase_order",
+   "description": "Sets 'Warehouse' in each row of the Items table.",
+   "fieldname": "set_warehouse",
+   "fieldtype": "Link",
+   "label": "Set Target Warehouse",
+   "options": "Warehouse",
+   "print_hide": 1
+  },
+  {
+   "allow_bulk_edit": 1,
+   "depends_on": "purchase_order",
+   "fieldname": "items",
+   "fieldtype": "Table",
+   "label": "Items",
+   "options": "Subcontracting Order Item",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_32",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "purchase_order",
+   "fieldname": "total_qty",
+   "fieldtype": "Float",
+   "label": "Total Quantity",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_29",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "purchase_order",
+   "fieldname": "total",
+   "fieldtype": "Currency",
+   "label": "Total",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "purchase_order",
+   "fieldname": "service_items_section",
+   "fieldtype": "Section Break",
+   "label": "Service Items"
+  },
+  {
+   "fieldname": "service_items",
+   "fieldtype": "Table",
+   "label": "Service Items",
+   "options": "Subcontracting Order Service Item",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "supplied_items",
+   "depends_on": "supplied_items",
+   "fieldname": "raw_materials_supplied_section",
+   "fieldtype": "Section Break",
+   "label": "Raw Materials Supplied"
+  },
+  {
+   "depends_on": "supplied_items",
+   "description": "Sets 'Reserve Warehouse' in each row of the Supplied Items table.",
+   "fieldname": "set_reserve_warehouse",
+   "fieldtype": "Link",
+   "label": "Set Reserve Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "supplied_items",
+   "fieldtype": "Table",
+   "label": "Supplied Items",
+   "no_copy": 1,
+   "options": "Subcontracting Order Supplied Item",
+   "print_hide": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "total_additional_costs",
+   "depends_on": "eval:(doc.docstatus == 0 || doc.total_additional_costs)",
+   "fieldname": "additional_costs_section",
+   "fieldtype": "Section Break",
+   "label": "Additional Costs"
+  },
+  {
+   "fieldname": "additional_costs",
+   "fieldtype": "Table",
+   "label": "Additional Costs",
+   "options": "Landed Cost Taxes and Charges"
+  },
+  {
+   "fieldname": "total_additional_costs",
+   "fieldtype": "Currency",
+   "label": "Total Additional Costs",
+   "print_hide_if_no_value": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "order_status_section",
+   "fieldtype": "Section Break",
+   "label": "Order Status"
+  },
+  {
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_standard_filter": 1,
+   "label": "Status",
+   "no_copy": 1,
+   "options": "Draft\nOpen\nPartially Received\nCompleted\nMaterial Transferred\nPartial Material Transferred\nCancelled",
+   "print_hide": 1,
+   "read_only": 1,
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_39",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:!doc.__islocal",
+   "fieldname": "per_received",
+   "fieldtype": "Percent",
+   "in_list_view": 1,
+   "label": "% Received",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "printing_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Printing Settings",
+   "print_hide": 1,
+   "print_width": "50%",
+   "width": "50%"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "select_print_heading",
+   "fieldtype": "Link",
+   "label": "Print Heading",
+   "no_copy": 1,
+   "options": "Print Heading",
+   "print_hide": 1,
+   "report_hide": 1
+  },
+  {
+   "fieldname": "column_break_43",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "letter_head",
+   "fieldtype": "Link",
+   "label": "Letter Head",
+   "options": "Letter Head",
+   "print_hide": 1
+  },
+  {
+   "default": "Qty",
+   "fieldname": "distribute_additional_costs_based_on",
+   "fieldtype": "Select",
+   "label": "Distribute Additional Costs Based On ",
+   "options": "Qty\nAmount"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions"
+  },
+  {
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center"
+  },
+  {
+   "fieldname": "dimension_col_break",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
+  }
+ ],
+ "icon": "fa fa-file-text",
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2023-01-06 00:36:22.439538",
+ "modified_by": "Administrator",
+ "module": "Subcontracting",
+ "name": "Subcontracting Order",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "report": 1,
+   "role": "Stock User"
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Purchase Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Purchase User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "Purchase Manager",
+   "write": 1
+  }
+ ],
+ "search_fields": "status, transaction_date, supplier",
+ "show_name_in_global_search": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "timeline_field": "supplier",
+ "title_field": "supplier_name",
+ "track_changes": 1
 }

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -169,8 +169,8 @@ class SubcontractingOrder(SubcontractingController):
 				else:
 					total_required_qty = total_supplied_qty = 0
 					for item in self.supplied_items:
-						total_required_qty += item.required_qty
-						total_supplied_qty += flt(item.supplied_qty)
+						total_required_qty += item.required_qty if not item.sourced_by_supplier else 0
+						total_supplied_qty += flt(item.supplied_qty) if not item.sourced_by_supplier else 0
 					if total_supplied_qty:
 						status = "Partial Material Transferred"
 						if total_supplied_qty >= total_required_qty:

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -86,7 +86,6 @@ class SubcontractingOrder(SubcontractingController):
 		for idx, item in enumerate(self.get("service_items")):
 			self.items[idx].service_cost_per_qty = item.amount / self.items[idx].qty
 
-	@frappe.whitelist()
 	def set_missing_values_in_supplied_items(self):
 		for item in self.get("items"):
 			rm_cost = sum(

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -91,7 +91,7 @@ class SubcontractingOrder(SubcontractingController):
 			rm_cost = sum(
 				flt(rm_item.get("amount"))
 				for rm_item in self.get("supplied_items")
-				if not rm_item.get("sourced_by_supplier")
+				if not rm_item.get("sourced_by_supplier") and item.item_code == rm_item.main_item_code
 			)
 			item.rm_cost_per_qty = rm_cost / flt(item.get("qty"))
 

--- a/erpnext/subcontracting/doctype/subcontracting_order_supplied_item/subcontracting_order_supplied_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_order_supplied_item/subcontracting_order_supplied_item.json
@@ -1,177 +1,185 @@
 {
-    "actions": [],
-    "creation": "2022-04-01 19:29:30.923800",
-    "doctype": "DocType",
-    "editable_grid": 1,
-    "engine": "InnoDB",
-    "field_order": [
-        "main_item_code",
-        "rm_item_code",
-        "column_break_3",
-        "stock_uom",
-        "conversion_factor",
-        "reserve_warehouse",
-        "column_break_6",
-        "bom_detail_no",
-        "reference_name",
-        "section_break_9",
-        "rate",
-        "column_break_11",
-        "amount",
-        "section_break_13",
-        "required_qty",
-        "supplied_qty",
-        "column_break_16",
-        "consumed_qty",
-        "returned_qty",
-        "total_supplied_qty"
-    ],
-    "fields": [
-        {
-            "columns": 2,
-            "fieldname": "main_item_code",
-            "fieldtype": "Link",
-            "in_list_view": 1,
-            "label": "Item Code",
-            "options": "Item",
-            "read_only": 1
-        },
-        {
-            "columns": 2,
-            "fieldname": "rm_item_code",
-            "fieldtype": "Link",
-            "in_list_view": 1,
-            "label": "Raw Material Item Code",
-            "options": "Item",
-            "read_only": 1
-        },
-        {
-            "fieldname": "column_break_3",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "stock_uom",
-            "fieldtype": "Link",
-            "label": "Stock Uom",
-            "options": "UOM",
-            "read_only": 1
-        },
-        {
-            "default": "1",
-            "fieldname": "conversion_factor",
-            "fieldtype": "Float",
-            "hidden": 1,
-            "label": "Conversion Factor",
-            "read_only": 1
-        },
-        {
-            "columns": 2,
-            "fieldname": "reserve_warehouse",
-            "fieldtype": "Link",
-            "in_list_view": 1,
-            "label": "Reserve Warehouse",
-            "options": "Warehouse"
-        },
-        {
-            "fieldname": "column_break_6",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "bom_detail_no",
-            "fieldtype": "Data",
-            "label": "BOM Detail No",
-            "read_only": 1
-        },
-        {
-            "fieldname": "reference_name",
-            "fieldtype": "Data",
-            "label": "Reference Name",
-            "read_only": 1
-        },
-        {
-            "fieldname": "section_break_9",
-            "fieldtype": "Section Break"
-        },
-        {
-            "columns": 2,
-            "fieldname": "rate",
-            "fieldtype": "Currency",
-            "in_list_view": 1,
-            "label": "Rate",
-            "options": "Company:company:default_currency"
-        },
-        {
-            "fieldname": "column_break_11",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "amount",
-            "fieldtype": "Currency",
-            "label": "Amount",
-            "options": "Company:company:default_currency",
-            "read_only": 1
-        },
-        {
-            "fieldname": "section_break_13",
-            "fieldtype": "Section Break"
-        },
-        {
-            "columns": 2,
-            "fieldname": "required_qty",
-            "fieldtype": "Float",
-            "in_list_view": 1,
-            "label": "Required Qty",
-            "read_only": 1
-        },
-        {
-            "fieldname": "supplied_qty",
-            "fieldtype": "Float",
-            "in_list_view": 1,
-            "label": "Supplied Qty",
-            "no_copy": 1,
-            "print_hide": 1,
-            "read_only": 1
-        },
-        {
-            "fieldname": "column_break_16",
-            "fieldtype": "Column Break"
-        },
-        {
-            "fieldname": "consumed_qty",
-            "fieldtype": "Float",
-            "label": "Consumed Qty",
-            "no_copy": 1,
-            "print_hide": 1,
-            "read_only": 1
-        },
-        {
-            "fieldname": "returned_qty",
-            "fieldtype": "Float",
-            "label": "Returned Qty",
-            "no_copy": 1,
-            "print_hide": 1,
-            "read_only": 1
-        },
-        {
-            "fieldname": "total_supplied_qty",
-            "fieldtype": "Float",
-            "hidden": 1,
-            "label": "Total Supplied Qty",
-            "no_copy": 1,
-            "print_hide": 1,
-            "read_only": 1
-        }
-    ],
-    "hide_toolbar": 1,
-    "istable": 1,
-    "links": [],
-    "modified": "2022-08-26 16:04:56.125951",
-    "modified_by": "Administrator",
-    "module": "Subcontracting",
-    "name": "Subcontracting Order Supplied Item",
-    "owner": "Administrator",
-    "permissions": [],
-    "sort_field": "modified",
-    "sort_order": "DESC",
-    "states": []
+ "actions": [],
+ "creation": "2022-04-01 19:29:30.923800",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "main_item_code",
+  "rm_item_code",
+  "column_break_3",
+  "stock_uom",
+  "conversion_factor",
+  "reserve_warehouse",
+  "column_break_6",
+  "bom_detail_no",
+  "reference_name",
+  "section_break_9",
+  "rate",
+  "column_break_11",
+  "amount",
+  "section_break_13",
+  "required_qty",
+  "supplied_qty",
+  "sourced_by_supplier",
+  "column_break_16",
+  "consumed_qty",
+  "returned_qty",
+  "total_supplied_qty"
+ ],
+ "fields": [
+  {
+   "columns": 2,
+   "fieldname": "main_item_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item Code",
+   "options": "Item",
+   "read_only": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "rm_item_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Raw Material Item Code",
+   "options": "Item",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "stock_uom",
+   "fieldtype": "Link",
+   "label": "Stock Uom",
+   "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "conversion_factor",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "Conversion Factor",
+   "read_only": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "reserve_warehouse",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Reserve Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "column_break_6",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "bom_detail_no",
+   "fieldtype": "Data",
+   "label": "BOM Detail No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reference_name",
+   "fieldtype": "Data",
+   "label": "Reference Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_9",
+   "fieldtype": "Section Break"
+  },
+  {
+   "columns": 1,
+   "fieldname": "rate",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Rate",
+   "options": "Company:company:default_currency"
+  },
+  {
+   "fieldname": "column_break_11",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "label": "Amount",
+   "options": "Company:company:default_currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_13",
+   "fieldtype": "Section Break"
+  },
+  {
+   "columns": 1,
+   "fieldname": "required_qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Required Qty",
+   "read_only": 1
+  },
+  {
+   "fieldname": "supplied_qty",
+   "fieldtype": "Float",
+   "label": "Supplied Qty",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_16",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "consumed_qty",
+   "fieldtype": "Float",
+   "label": "Consumed Qty",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "returned_qty",
+   "fieldtype": "Float",
+   "label": "Returned Qty",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_supplied_qty",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "Total Supplied Qty",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "columns": 1,
+   "default": "0",
+   "fieldname": "sourced_by_supplier",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Sourced by Supplier"
+  }
+ ],
+ "hide_toolbar": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2023-01-05 09:25:37.962325",
+ "modified_by": "Administrator",
+ "module": "Subcontracting",
+ "name": "Subcontracting Order Supplied Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
 }

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -518,15 +518,15 @@ class TestSubcontractingReceipt(FrappeTestCase):
 		# consumed_qty should be (accepted_qty * (transfered_qty / qty)) = (5 * (20 / 10)) = 10
 		self.assertEqual(scr.supplied_items[0].consumed_qty, 10)
 
-		# # Set Backflush Based On as "BOM"
-		# set_backflush_based_on("BOM")
+		# Set Backflush Based On as "BOM"
+		set_backflush_based_on("BOM")
 
-		# scr.items[0].qty = 6  # Accepted Qty
-		# scr.items[0].rejected_qty = 4
-		# scr.save()
+		scr.items[0].qty = 6  # Accepted Qty
+		scr.items[0].rejected_qty = 4
+		scr.save()
 
-		# # consumed_qty should be (accepted_qty * qty_consumed_per_unit) = (6 * 1) = 6
-		# self.assertEqual(scr.supplied_items[0].consumed_qty, 6)
+		# consumed_qty should be (accepted_qty * qty_consumed_per_unit) = (6 * 1) = 6
+		self.assertEqual(scr.supplied_items[0].consumed_qty, 6)
 
 
 def make_return_subcontracting_receipt(**args):

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -518,16 +518,6 @@ class TestSubcontractingReceipt(FrappeTestCase):
 		# consumed_qty should be (accepted_qty * (transfered_qty / qty)) = (5 * (20 / 10)) = 10
 		self.assertEqual(scr.supplied_items[0].consumed_qty, 10)
 
-		# Set Backflush Based On as "BOM"
-		set_backflush_based_on("BOM")
-
-		scr.items[0].qty = 6  # Accepted Qty
-		scr.items[0].rejected_qty = 4
-		scr.save()
-
-		# consumed_qty should be (accepted_qty * qty_consumed_per_unit) = (6 * 1) = 6
-		self.assertEqual(scr.supplied_items[0].consumed_qty, 6)
-
 
 def make_return_subcontracting_receipt(**args):
 	args = frappe._dict(args)

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -518,6 +518,16 @@ class TestSubcontractingReceipt(FrappeTestCase):
 		# consumed_qty should be (accepted_qty * (transfered_qty / qty)) = (5 * (20 / 10)) = 10
 		self.assertEqual(scr.supplied_items[0].consumed_qty, 10)
 
+		# # Set Backflush Based On as "BOM"
+		# set_backflush_based_on("BOM")
+
+		# scr.items[0].qty = 6  # Accepted Qty
+		# scr.items[0].rejected_qty = 4
+		# scr.save()
+
+		# # consumed_qty should be (accepted_qty * qty_consumed_per_unit) = (6 * 1) = 6
+		# self.assertEqual(scr.supplied_items[0].consumed_qty, 6)
+
 
 def make_return_subcontracting_receipt(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
1. Added `Sourced by Supplier` in SCO under Raw Materials Item Supplied.
2. If Sourced by Supplier is checked in Raw Materials Item Supplied it sets the rate and amount to 0 and updates raw material cost in SCO Items.
3. While creating stock entry for material transfer it does not fetch items which are sourced by supplier.

![sco](https://user-images.githubusercontent.com/53251406/211511665-f376b986-8ab5-497c-b4b8-1593de0e7ed3.gif)
